### PR TITLE
Prevent JsonFeedAuthor empty from serializing

### DIFF
--- a/jsonfeed-core/src/main/java/io/micronaut/rss/jsonfeed/JsonFeedAuthor.java
+++ b/jsonfeed-core/src/main/java/io/micronaut/rss/jsonfeed/JsonFeedAuthor.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * @author Sergio del Amo, mark1626
  * @since 2.2.0
  */
-@Introspected
+@Introspected(excludes = "empty")
 public class JsonFeedAuthor {
 
     public static final String KEY_AVATAR = "avatar";

--- a/jsonfeed-core/src/test/groovy/io/micronaut/rss/jsonfeed/JsonFeedAuthorSpec.groovy
+++ b/jsonfeed-core/src/test/groovy/io/micronaut/rss/jsonfeed/JsonFeedAuthorSpec.groovy
@@ -1,14 +1,16 @@
 package io.micronaut.rss.jsonfeed
 
+import groovy.json.JsonSlurper
 import io.micronaut.core.beans.BeanIntrospection
 
 class JsonFeedAuthorSpec extends ApplicationContextSpecification {
     void "JsonFeedAuthor is annotated with Introspected"() {
         when:
-        BeanIntrospection.getIntrospection(JsonFeedAuthor)
+        BeanIntrospection<JsonFeedAuthor> introspection = BeanIntrospection.getIntrospection(JsonFeedAuthor)
 
         then:
         noExceptionThrown()
+        !introspection.propertyNames.contains("empty")
     }
 
     void "valid JsonFeedAuthor does not trigger any constraint exception"() {
@@ -76,6 +78,25 @@ class JsonFeedAuthorSpec extends ApplicationContextSpecification {
         "Sergio del Amo" == author.name
         "https://sergiodelamo.com" == author.url
         "https://sergiodelamo.com/images/sergiodelamo.png" == author.avatar
+    }
+
+    void "json serialization does not include empty property"() {
+        given:
+        JsonFeedAuthor author = JsonFeedAuthor.builder()
+                .name("Sergio del Amo")
+                .url("https://sergiodelamo.com")
+                .avatar("https://sergiodelamo.com/images/sergiodelamo.png")
+                .build()
+
+        when:
+        String json = objectMapper.writeValueAsString(author)
+        def serialized = new JsonSlurper().parseText(json) as Map<String, Object>
+
+        then:
+        !serialized.containsKey("empty")
+        serialized.name == "Sergio del Amo"
+        serialized.url == "https://sergiodelamo.com"
+        serialized.avatar == "https://sergiodelamo.com/images/sergiodelamo.png"
     }
 
     void "avatar is optional"() {

--- a/jsonfeed-core/src/test/groovy/io/micronaut/rss/jsonfeed/JsonFeedItemSpec.groovy
+++ b/jsonfeed-core/src/test/groovy/io/micronaut/rss/jsonfeed/JsonFeedItemSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.rss.jsonfeed
 
+import groovy.json.JsonSlurper
 import io.micronaut.core.beans.BeanIntrospection
 
 import java.time.LocalDateTime
@@ -260,6 +261,29 @@ class JsonFeedItemSpec extends ApplicationContextSpecification {
         json.contains('date_modified')
         json.contains('external_url')
         json.contains('content_html')
+    }
+
+    void "serialized feed authors do not include empty property"() {
+        given:
+        JsonFeed jsonFeed = JsonFeed.builder("https://jsonfeed.org/version/1.1",
+                "Example Feed",
+                Collections.singletonList(JsonFeedItem.builder("1")
+                        .contentText("Hello, world!")
+                        .author(JsonFeedAuthor.builder()
+                                .name("Item Author")
+                                .build())
+                        .build()))
+                .author(JsonFeedAuthor.builder()
+                        .name("Feed Author")
+                        .build())
+                .build()
+
+        when:
+        Map<String, Object> serialized = new JsonSlurper().parseText(objectMapper.writeValueAsString(jsonFeed)) as Map<String, Object>
+
+        then:
+        !serialized.authors[0].containsKey("empty")
+        !serialized.items[0].authors[0].containsKey("empty")
     }
 
     static JsonFeedItem validJsonFeedItem() {

--- a/jsonfeed/src/test/groovy/io/micronaut/rss/jsonfeed/http/JsonFeedControllerSpec.groovy
+++ b/jsonfeed/src/test/groovy/io/micronaut/rss/jsonfeed/http/JsonFeedControllerSpec.groovy
@@ -27,10 +27,21 @@ class JsonFeedControllerSpec extends Specification {
     "title": "My Example Feed",
     "home_page_url": "https://example.org/",
     "feed_url": "https://example.org/feed.json",
+    "authors": [
+        {
+            "name": "Feed Author",
+            "url": "mailto:feed@example.org"
+        }
+    ],
     "items": [
         {
             "id": "2",
             "content_text": "This is a second item.",
+            "authors": [
+                {
+                    "name": "Item Author"
+                }
+            ],
             "url": "https://example.org/second-item"
         },
         {
@@ -61,10 +72,15 @@ class JsonFeedControllerSpec extends Specification {
         m['title'] == result['title']
         m['home_page_url'] == result['home_page_url']
         m['feed_url'] ==  result['feed_url']
+        m['authors'][0]['name'] == result['authors'][0]['name']
+        m['authors'][0]['url'] == result['authors'][0]['url']
+        !result['authors'][0].containsKey('empty')
         result['items']
         m['items'].size() == result['items'].size()
         m['items'][0].id == result['items'][0].id
         m['items'][0]['content_text'] == result['items'][0]['content_text']
+        m['items'][0]['authors'][0]['name'] == result['items'][0]['authors'][0]['name']
+        !result['items'][0]['authors'][0].containsKey('empty')
         m['items'][0]['url'] == result['items'][0]['url']
 
         m['items'][1].id == result['items'][1].id

--- a/jsonfeed/src/test/java/io/micronaut/rss/jsonfeed/http/ExampleJsonFeedProvider.java
+++ b/jsonfeed/src/test/java/io/micronaut/rss/jsonfeed/http/ExampleJsonFeedProvider.java
@@ -4,6 +4,7 @@ import io.micronaut.context.annotation.Requires;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.async.annotation.SingleResult;
+import io.micronaut.rss.jsonfeed.JsonFeedAuthor;
 import io.micronaut.rss.jsonfeed.JsonFeed;
 import io.micronaut.rss.jsonfeed.JsonFeedItem;
 import reactor.core.publisher.Flux;
@@ -26,9 +27,16 @@ public class ExampleJsonFeedProvider implements JsonFeedProvider {
                     .title("My Example Feed")
                     .homePageUrl("https://example.org/")
                     .feedUrl("https://example.org/feed.json")
+                    .author(JsonFeedAuthor.builder()
+                            .name("Feed Author")
+                            .url("mailto:feed@example.org")
+                            .build())
                     .item(JsonFeedItem.builder()
                             .id("2")
                             .contentText("This is a second item.")
+                            .author(JsonFeedAuthor.builder()
+                                    .name("Item Author")
+                                    .build())
                             .url("https://example.org/second-item")
                             .build())
                     .item(JsonFeedItem.builder()


### PR DESCRIPTION
## Summary
- exclude the derived `empty` property from `JsonFeedAuthor` introspection
- add serialization coverage for `JsonFeedAuthor`, nested feed/item authors, and the JSON feed controller response

Resolves #382